### PR TITLE
Update the EditorConfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,12 @@ indent_size = 4
 
 [{*.json,*.yaml,*.yml}]
 indent_size = 2
+
+# Ignore lark files
+[*.lark]
+charset = unset
+insert_final_newline = unset
+end_of_line = unset
+indent_style = unset
+trim_trailing_whitespace = unset
+indent_size = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ indent_style = space
 trim_trailing_whitespace = true
 indent_size = 4
 
-[*.json,*.yaml,*.yml]
+[{*.json,*.yaml,*.yml}]
 indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,7 @@ repos:
         additional_dependencies:
           - geojson-pydantic
           - lark
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: 2.7.3
+    hooks:
+      - id: editorconfig-checker


### PR DESCRIPTION
This PR introduces the following changes:

* Fix a syntax error in the EditorConfig rules
* Ignore lark files in the EditorConfig rules
* Add a pre-commit hook to validate EditorConfig enforcement

Prior to this PR, the JSON/YAML/lark files failed to pass EditorConfig validation.